### PR TITLE
Add enhanced revenue model notebook

### DIFF
--- a/4_enhanced_revenue_model.ipynb
+++ b/4_enhanced_revenue_model.ipynb
@@ -1,0 +1,245 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Enhanced AAA Movie Revenue Prediction\n",
+        "\n",
+        "This notebook expands upon `2_predict_aaa_movies.ipynb` by integrating richer data sources, advanced feature engineering, and state-of-the-art models.\n",
+        "\n",
+        "## Setup\n",
+        "* Install additional libraries:\n",
+        "  ```bash\n",
+        "  pip install lightgbm catboost optuna featuretools networkx transformers sentencepiece kaggle pytrends\n",
+        "  ```\n",
+        "* Optional data downloads:\n",
+        "  * [The Numbers](https://www.the-numbers.com/market/) or [Box Office Mojo](https://www.boxofficemojo.com/) CSV exports for worldwide box office and marketing spend.\n",
+        "  * [Rotten Tomatoes Open Dataset](https://www.kaggle.com/datasets/dalziel/rotten-tomatoes-movies-and-critics-dataset) or [Metacritic data](https://www.kaggle.com/datasets/PromptCloudHQ/imdb-data) for critic and audience sentiment.\n",
+        "  * [Google Trends](https://trends.google.com/) via `pytrends` for pre-release search interest.\n",
+        "  * Social media buzz from Twitter API v2 or other sources.\n",
+        "\n",
+        "Ensure that the original DuckDB database from previous notebooks is available at `data/movies.duckdb`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Uncomment to install new dependencies in a fresh environment\n",
+        "%pip install lightgbm catboost optuna featuretools networkx transformers sentencepiece kaggle pytrends -q\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import duckdb, pandas as pd, numpy as np\n",
+        "import featuretools as ft\n",
+        "import networkx as nx\n",
+        "from transformers import AutoTokenizer, AutoModel\n",
+        "from pytrends.request import TrendReq\n",
+        "import lightgbm as lgb, catboost as cb\n",
+        "import optuna\n",
+        "\n",
+        "con = duckdb.connect('data/movies.duckdb')\n",
+        "movies = con.execute('SELECT * FROM movies').df()\n",
+        "movies.head()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## External data integration\n",
+        "### Box office and marketing spend\n",
+        "Merge additional financial data from Box Office Mojo or The Numbers.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# numbers = pd.read_csv('data/the_numbers.csv')  # download separately\n",
+        "# movies = movies.merge(numbers, on='primary_title', how='left')\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Critic and audience scores\n",
+        "Ingest Rotten Tomatoes or Metacritic scores to capture sentiment.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# rt = pd.read_csv('data/rotten_tomatoes.csv')\n",
+        "# movies = movies.merge(rt, on='imdb_id', how='left')\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Social trend features\n",
+        "Use Google Trends to estimate pre-release buzz for each title.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# pytrends = TrendReq()\n",
+        "# pytrends.build_payload([title], timeframe='2020-01-01 2020-12-31')\n",
+        "# interest = pytrends.interest_over_time()\n",
+        "# movies.loc[movies.primary_title == title, 'google_trends'] = interest[title].mean()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Cast & crew networks\n",
+        "Model collaboration networks using `networkx` to quantify star power.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# G = nx.Graph()\n",
+        "# for _, row in cast_df.iterrows():\n",
+        "#     G.add_edge(row['title_id'], row['person_id'])\n",
+        "# movies['degree_centrality'] = movies['tconst'].map(nx.degree_centrality(G))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Plot summary embeddings\n",
+        "Extract semantic features from plot summaries using Transformers.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# tokenizer = AutoTokenizer.from_pretrained('sentence-transformers/all-MiniLM-L6-v2')\n",
+        "# model = AutoModel.from_pretrained('sentence-transformers/all-MiniLM-L6-v2')\n",
+        "# def embed(text):\n",
+        "#     tokens = tokenizer(text, return_tensors='pt', truncation=True, padding=True)\n",
+        "#     return model(**tokens).last_hidden_state.mean(dim=1).detach().numpy()\n",
+        "# movies['plot_embedding'] = movies['plot'].apply(embed)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Automated feature generation\n",
+        "Leverage `featuretools` for deep feature synthesis.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# es = ft.EntitySet.from_dataframe('movies', movies, index='tconst')\n",
+        "# feature_matrix, feature_defs = ft.dfs(entityset=es, target_entity='movies')\n",
+        "# movies = feature_matrix\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Modeling with hyperparameter tuning and ensembling\n",
+        "Train LightGBM and CatBoost models with Optuna for hyperparameter search and ensemble their predictions.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.metrics import mean_absolute_percentage_error, r2_score\n",
+        "\n",
+        "y = movies['revenue']\n",
+        "X = movies.drop(columns=['revenue'])\n",
+        "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
+        "\n",
+        "def objective(trial):\n",
+        "    params = {\n",
+        "        'objective': 'regression',\n",
+        "        'metric': 'mape',\n",
+        "        'num_leaves': trial.suggest_int('num_leaves', 31, 256),\n",
+        "        'learning_rate': trial.suggest_loguniform('learning_rate', 1e-3, 0.3),\n",
+        "        'feature_fraction': trial.suggest_float('feature_fraction', 0.6, 1.0)\n",
+        "    }\n",
+        "    dtrain = lgb.Dataset(X_train, label=y_train)\n",
+        "    gbm = lgb.train(params, dtrain, num_boost_round=100)\n",
+        "    preds = gbm.predict(X_test)\n",
+        "    return mean_absolute_percentage_error(y_test, preds)\n",
+        "\n",
+        "# study = optuna.create_study(direction='minimize')\n",
+        "# study.optimize(objective, n_trials=30)\n",
+        "# best_params = study.best_trial.params\n",
+        "# final_model = lgb.train({**best_params, 'objective': 'regression'}, dtrain)\n",
+        "\n",
+        "# CatBoost and ensembling\n",
+        "# cat_model = cb.CatBoostRegressor(loss_function='MAPE', verbose=False)\n",
+        "# cat_model.fit(X_train, y_train)\n",
+        "# lgb_pred = final_model.predict(X_test)\n",
+        "# cat_pred = cat_model.predict(X_test)\n",
+        "# ensemble_pred = (lgb_pred + cat_pred) / 2\n",
+        "# print('MAPE:', mean_absolute_percentage_error(y_test, ensemble_pred))\n",
+        "# print('R^2:', r2_score(y_test, ensemble_pred))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Next steps\n",
+        "* Log experiments with MLflow or Weights & Biases.\n",
+        "* Apply SHAP for model explainability.\n",
+        "* Deploy the trained model as a web service or batch scoring job.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Below is the full process:
 2. Run `ingest_imdb.py`, `profile_datasets.py` and then `ingest_other_datasets.py`
 3. Continue running the code in `download_and_explore_data.ipynb`
 4. Run `predict_aaa_movies.ipynb`
+5. For an experimental, feature-rich workflow open `4_enhanced_revenue_model.ipynb`. Install extra dependencies with:
+   ```bash
+   pip install lightgbm catboost optuna featuretools networkx transformers sentencepiece kaggle pytrends
+   ```
+   This notebook demonstrates how to merge external box-office data (Box Office Mojo or The Numbers), critic scores (Rotten Tomatoes/Metacritic) and social-trend signals, generate network and text features, and train tuned LightGBM/CatBoost ensembles.
 
 The notebook `webscraping.ipynb` is provided as an attempt to obtain box office data from Wikidata. However I found out it is insufficient for my purposes. 
 


### PR DESCRIPTION
## Summary
- add `4_enhanced_revenue_model.ipynb` outlining richer data sources, network/text features, and tuned LightGBM/CatBoost models
- document new workflow and required dependencies in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcf1a96a7c832cbf72c1073022babd